### PR TITLE
Negate current speed variable for vesc_to_odom package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Packages to interface with Veddar VESC motor controllers. See https://vesc-proje
 
 This is a ROS2 implementation of the ROS1 driver using the new serial driver located in [transport drivers](https://github.com/ros-drivers/transport_drivers).
 
+## Changes made from upstream
+
+* Updated `README.md` with this change notice
+* Negated the `current_speed` value in `vesc_to_odom.cpp`
+
 ## How to test
 
 1. Clone this repository and [transport drivers](https://github.com/ros-drivers/transport_drivers) into `src`.

--- a/vesc_ackermann/src/vesc_to_odom.cpp
+++ b/vesc_ackermann/src/vesc_to_odom.cpp
@@ -28,6 +28,9 @@
 
 // -*- mode:c++; fill-column: 100; -*-
 
+// Changes made from upstream
+// - negated current_speed value
+
 #include "vesc_ackermann/vesc_to_odom.hpp"
 
 #include <cmath>
@@ -98,8 +101,10 @@ void VescToOdom::vescStateCallback(const VescStateStamped::SharedPtr state)
     return;
   }
 
+  // Begin change from upstream
   // convert to engineering units
-  double current_speed = (-state->state.speed - speed_to_erpm_offset_) / speed_to_erpm_gain_;
+  double current_speed = -(-state->state.speed - speed_to_erpm_offset_) / speed_to_erpm_gain_;
+  // End change from upstream
   if (std::fabs(current_speed) < 0.05) {
     current_speed = 0.0;
   }


### PR DESCRIPTION
# PR Details
## Description

This PR negates the `current_speed` value in the `vesc_to_odom` package. This change is necessary for accurate odometry from the C1T truck and is the recommended approach to tuning the VESC (see [F1Tenth Docs](https://f1tenth.readthedocs.io/en/foxy_test/getting_started/driving/drive_calib_odom.html)).

## Related GitHub Issue

## Related Jira Key

Closes [CF-797](https://usdot-carma.atlassian.net/browse/CF-797)

## Motivation and Context

Needed to accurate odometry on C1T trucks

## How Has This Been Tested?

Manually

## Types of changes

- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CF-797]: https://usdot-carma.atlassian.net/browse/CF-797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ