### PR TITLE
added low pass filter to servo commands for smoother steering

### DIFF
--- a/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
+++ b/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
@@ -56,8 +56,8 @@ private:
   double steering_to_servo_gain_, steering_to_servo_offset_;
   // Begin change from upstream
   double Kp_, Ki_, Kd_;
+  double steering_feedback_, steering_error_sum_, previous_steering_error_;
   // End change from upstream
-  double servo_feedback_, servo_error_sum_, previous_servo_error_;
 
   /** @todo consider also providing an interpolated look-up table conversion */
 

--- a/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
+++ b/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
@@ -55,8 +55,8 @@ private:
   double speed_to_erpm_gain_, speed_to_erpm_offset_;
   double steering_to_servo_gain_, steering_to_servo_offset_;
   // Begin change from upstream
-  double Kp_, Ki_, Kd_;
-  double steering_feedback_, steering_error_sum_, previous_steering_error_;
+  double cutoff_frequency_, Epow_;
+  double steering_feedback_;
   // End change from upstream
 
   /** @todo consider also providing an interpolated look-up table conversion */

--- a/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
+++ b/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
@@ -28,6 +28,9 @@
 
 // -*- mode:c++; fill-column: 100; -*-
 
+// Changes from upstream
+// - added gains for PID controller as parameters
+
 #ifndef VESC_ACKERMANN__ACKERMANN_TO_VESC_HPP_
 #define VESC_ACKERMANN__ACKERMANN_TO_VESC_HPP_
 
@@ -51,7 +54,9 @@ private:
   // conversion gain and offset
   double speed_to_erpm_gain_, speed_to_erpm_offset_;
   double steering_to_servo_gain_, steering_to_servo_offset_;
+  // Begin change from upstream
   double Kp_, Ki_, Kd_;
+  // End change from upstream
   double servo_feedback_, servo_error_sum_, previous_servo_error_;
 
   /** @todo consider also providing an interpolated look-up table conversion */

--- a/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
+++ b/vesc_ackermann/include/vesc_ackermann/ackermann_to_vesc.hpp
@@ -51,6 +51,8 @@ private:
   // conversion gain and offset
   double speed_to_erpm_gain_, speed_to_erpm_offset_;
   double steering_to_servo_gain_, steering_to_servo_offset_;
+  double Kp_, Ki_, Kd_;
+  double servo_feedback_, servo_error_sum_, previous_servo_error_;
 
   /** @todo consider also providing an interpolated look-up table conversion */
 

--- a/vesc_ackermann/src/ackermann_to_vesc.cpp
+++ b/vesc_ackermann/src/ackermann_to_vesc.cpp
@@ -61,6 +61,9 @@ AckermannToVesc::AckermannToVesc(const rclcpp::NodeOptions & options)
   Kp_ = declare_parameter<double>("Kp");
   Ki_ = declare_parameter<double>("Ki");
   Kd_ = declare_parameter<double>("Kd");
+  steering_error_sum_ = 0.0;
+  previous_servo_error_ = 0.0;
+  steering_feedback_ = 0.0;
   // End changes from upstream
 
   // create publishers to vesc electric-RPM (speed) and servo commands
@@ -81,11 +84,12 @@ void AckermannToVesc::ackermannCmdCallback(const AckermannDriveStamped::SharedPt
   // calc steering angle (servo)
   Float64 servo_msg;
   // Begin changes from upstream
-  double servo_target = steering_to_servo_gain_ * cmd->drive.steering_angle + steering_to_servo_offset_;
-  double servo_error = servo_target - servo_feedback_;
-  servo_msg.data = Kp_ * servo_error + Ki_ * servo_error_sum_ + Kd_ * (servo_error - previous_servo_error_);
-  servo_error_sum_ += servo_error;
-  previous_servo_error_ = servo_error;
+  double steering_error = cmd->drive.steering_angle - steering_feedback_;
+  double steering_cmd = Kp_ * steering_error + Ki_ * steering_error_sum_ + Kd_ * (steering_error - previous_steering_error_)
+  servo_msg.data = steering_to_servo_gain_ * steering_cmd + steering_to_servo_offset_;
+  steering_error_sum_ += steering_error;
+  previous_steering_error_ = steering_error;
+  steering_feedback_ = steerind_cmd;
   // End changes from upstream
 
   // publish

--- a/vesc_ackermann/src/ackermann_to_vesc.cpp
+++ b/vesc_ackermann/src/ackermann_to_vesc.cpp
@@ -79,8 +79,14 @@ void AckermannToVesc::ackermannCmdCallback(const AckermannDriveStamped::SharedPt
 {
   // calc vesc electric RPM (speed)
   Float64 erpm_msg;
-  erpm_msg.data = speed_to_erpm_gain_ * cmd->drive.speed + speed_to_erpm_offset_;
-
+  if (cmd->drive.speed < 0.0) 
+  {
+  	erpm_msg.data = speed_to_erpm_offset_;
+  } 
+  else 
+  {
+  	erpm_msg.data = speed_to_erpm_gain_ * cmd->drive.speed + speed_to_erpm_offset_;
+  }
   // calc steering angle (servo)
   Float64 servo_msg;
   // Begin changes from upstream

--- a/vesc_ackermann/src/ackermann_to_vesc.cpp
+++ b/vesc_ackermann/src/ackermann_to_vesc.cpp
@@ -62,7 +62,7 @@ AckermannToVesc::AckermannToVesc(const rclcpp::NodeOptions & options)
   Ki_ = declare_parameter<double>("Ki");
   Kd_ = declare_parameter<double>("Kd");
   steering_error_sum_ = 0.0;
-  previous_servo_error_ = 0.0;
+  previous_steering_error_ = 0.0;
   steering_feedback_ = 0.0;
   // End changes from upstream
 
@@ -85,11 +85,11 @@ void AckermannToVesc::ackermannCmdCallback(const AckermannDriveStamped::SharedPt
   Float64 servo_msg;
   // Begin changes from upstream
   double steering_error = cmd->drive.steering_angle - steering_feedback_;
-  double steering_cmd = Kp_ * steering_error + Ki_ * steering_error_sum_ + Kd_ * (steering_error - previous_steering_error_)
+  double steering_cmd = Kp_ * steering_error + Ki_ * steering_error_sum_ + Kd_ * (steering_error - previous_steering_error_);
   servo_msg.data = steering_to_servo_gain_ * steering_cmd + steering_to_servo_offset_;
   steering_error_sum_ += steering_error;
   previous_steering_error_ = steering_error;
-  steering_feedback_ = steerind_cmd;
+  steering_feedback_ = steering_cmd;
   // End changes from upstream
 
   // publish

--- a/vesc_ackermann/src/ackermann_to_vesc.cpp
+++ b/vesc_ackermann/src/ackermann_to_vesc.cpp
@@ -28,6 +28,9 @@
 
 // -*- mode:c++; fill-column: 100; -*-
 
+// Changes made from upstream
+// - added PID controller for setting servo command
+
 #include "vesc_ackermann/ackermann_to_vesc.hpp"
 
 #include <cmath>
@@ -54,10 +57,11 @@ AckermannToVesc::AckermannToVesc(const rclcpp::NodeOptions & options)
     declare_parameter<double>("steering_angle_to_servo_gain");
   steering_to_servo_offset_ =
     declare_parameter<double>("steering_angle_to_servo_offset");
+  // Begin changes from upstream
   Kp_ = declare_parameter<double>("Kp");
   Ki_ = declare_parameter<double>("Ki");
   Kd_ = declare_parameter<double>("Kd");
-  
+  // End changes from upstream
 
   // create publishers to vesc electric-RPM (speed) and servo commands
   erpm_pub_ = create_publisher<Float64>("commands/motor/speed", 10);
@@ -76,11 +80,13 @@ void AckermannToVesc::ackermannCmdCallback(const AckermannDriveStamped::SharedPt
 
   // calc steering angle (servo)
   Float64 servo_msg;
+  // Begin changes from upstream
   double servo_target = steering_to_servo_gain_ * cmd->drive.steering_angle + steering_to_servo_offset_;
   double servo_error = servo_target - servo_feedback_;
   servo_msg.data = Kp_ * servo_error + Ki_ * servo_error_sum_ + Kd_ * (servo_error - previous_servo_error_);
   servo_error_sum_ += servo_error;
   previous_servo_error_ = servo_error;
+  // End changes from upstream
 
   // publish
   if (rclcpp::ok()) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds a low-pass filter in between the requested Ackermann steering angle and the servo command sent to the VESC to reduce noise in the truck's steering. 

## Related Jira Key

[CF-842](https://usdot-carma.atlassian.net/browse/CF-842)

## Motivation and Context

The C1T trucks have demonstrated erratic steering behavior when making turns in F-125. Although this has improved with a better VESC calibration, further software defined limitations will add additional smoothness to the steering.

## How Has This Been Tested?

Untested - Marked as draft

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CF-842]: https://usdot-carma.atlassian.net/browse/CF-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ